### PR TITLE
Drop UID field from test fixtures.

### DIFF
--- a/controllers/bootstrap_test.go
+++ b/controllers/bootstrap_test.go
@@ -25,7 +25,6 @@ const (
 	testConfigName  = "test-config"
 	testClusterName = "test-cluster"
 	testNamespace   = "testing"
-	testClusterUID  = "ecf40f3f-9341-4b1c-bc58-69ff2602d31b"
 )
 
 func Test_bootstrapClusterWithConfig(t *testing.T) {
@@ -80,7 +79,6 @@ func Test_bootstrapClusterWithConfig_sets_owner(t *testing.T) {
 			APIVersion: "cluster.x-k8s.io/v1beta1",
 			Kind:       "Cluster",
 			Name:       testClusterName,
-			UID:        testClusterUID,
 		},
 	}
 	if diff := cmp.Diff(want, jobList.Items[0].ObjectMeta.OwnerReferences); diff != "" {
@@ -127,7 +125,6 @@ func makeTestCluster(opts ...func(*clusterv1.Cluster)) *clusterv1.Cluster {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      testClusterName,
 			Namespace: testNamespace,
-			UID:       testClusterUID,
 		},
 		Spec: clusterv1.ClusterSpec{},
 	}

--- a/controllers/cluster_test.go
+++ b/controllers/cluster_test.go
@@ -7,7 +7,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
@@ -74,7 +73,6 @@ func makeNode(labels map[string]string, conds ...corev1.NodeCondition) *corev1.N
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   "test-control-plane",
 			Labels: labels,
-			UID:    types.UID("f046e20e-df55-40d0-ab3a-76ff56617575"),
 		},
 		Spec: corev1.NodeSpec{},
 		Status: corev1.NodeStatus{

--- a/controllers/clusterbootstrapconfig_controller_test.go
+++ b/controllers/clusterbootstrapconfig_controller_test.go
@@ -101,7 +101,8 @@ func TestReconcile_when_cluster_ready(t *testing.T) {
 	})
 	readyNode := makeNode(map[string]string{
 		"node-role.kubernetes.io/control-plane": "",
-	}, corev1.NodeCondition{Type: "Ready", Status: "True", LastHeartbeatTime: metav1.Now(), LastTransitionTime: metav1.Now(), Reason: "KubeletReady", Message: "kubelet is posting ready status"})
+	}, corev1.NodeCondition{
+		Type: "Ready", Status: "True", LastHeartbeatTime: metav1.Now(), LastTransitionTime: metav1.Now(), Reason: "KubeletReady", Message: "kubelet is posting ready status"})
 
 	cl := makeTestCluster(func(c *clusterv1.Cluster) {
 		c.ObjectMeta.Labels = bc.Spec.ClusterSelector.MatchLabels
@@ -209,7 +210,9 @@ func TestReconcile_when_cluster_ready_and_old_label(t *testing.T) {
 	})
 	readyNode := makeNode(map[string]string{
 		"node-role.kubernetes.io/master": "",
-	}, corev1.NodeCondition{Type: "Ready", Status: "True", LastHeartbeatTime: metav1.Now(), LastTransitionTime: metav1.Now(), Reason: "KubeletReady", Message: "kubelet is posting ready status"})
+	}, corev1.NodeCondition{Type: "Ready", Status: "True", LastHeartbeatTime: metav1.Now(),
+		LastTransitionTime: metav1.Now(), Reason: "KubeletReady",
+		Message: "kubelet is posting ready status"})
 
 	cl := makeTestCluster(func(c *clusterv1.Cluster) {
 		c.ObjectMeta.Labels = bc.Spec.ClusterSelector.MatchLabels


### PR DESCRIPTION
This drops the unused/unneeded UID field from created test clusters.