### PR TITLE
Mark fields as optional.

### DIFF
--- a/api/v1alpha1/clusterbootstrapconfig_types.go
+++ b/api/v1alpha1/clusterbootstrapconfig_types.go
@@ -49,10 +49,12 @@ type ClusterBootstrapConfigSpec struct {
 	// Wait for the remote cluster to be "ready" before creating the jobs.
 	// Defaults to false.
 	//+kubebuilder:default:false
+	//+optional
 	RequireClusterReady bool `json:"requireClusterReady"`
 	// When checking for readiness, this is the time to wait before
 	// checking again.
 	//+kubebuilder:default:60s
+	//+optional
 	ClusterReadinessBackoff *metav1.Duration `json:"clusterReadinessBackoff,omitempty"`
 }
 

--- a/config/crd/bases/capi.weave.works_clusterbootstrapconfigs.yaml
+++ b/config/crd/bases/capi.weave.works_clusterbootstrapconfigs.yaml
@@ -6900,7 +6900,6 @@ spec:
             required:
             - clusterSelector
             - jobTemplate
-            - requireClusterReady
             type: object
           status:
             description: ClusterBootstrapConfigStatus defines the observed state of


### PR DESCRIPTION
This marks the new requireClusterReady and clusterReadinessBackoff
fields as optional.