### PR TITLE
Improve security and add documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,7 @@ This is a controller that tracks [CAPI](https://github.com/kubernetes-sigs/clust
 
 It provides a CR for a `ClusterBootstrapConfig` which provides a [Job](https://kubernetes.io/docs/concepts/workloads/controllers/job/) template.
 
-When a CAPI Cluster is "provisioned" a Job is created from the template, the
-template can access multiple fields.
+When a CAPI Cluster is "provisioned" a Job is created from the template, the template can access multiple fields.
 
 ```yaml
 apiVersion: capi.weave.works/v1alpha1
@@ -35,10 +34,7 @@ spec:
           secretName: '{{ .ObjectMeta.Name }}-kubeconfig'
 ```
 
-This is using Go [templating](https://pkg.go.dev/text/template) and the
-`Cluster` object is provided as the context, this means that expressions like
-`{{ .ObjectMeta.Name }}` will get the _name_ of the Cluster that has
-transitioned to "provisioned".
+This is using Go [templating](https://pkg.go.dev/text/template) and the `Cluster` object is provided as the context, this means that expressions like `{{ .ObjectMeta.Name }}` will get the _name_ of the Cluster that has transitioned to "provisioned".
 
 ## Annotations
 
@@ -56,3 +52,16 @@ e.g.
           secretName: '{{ annotation "example.com/secret-name }}'
 
 ```
+
+## Installation
+
+You will need to have CAPI installed first, see the [CAPI Quick Start](https://cluster-api.sigs.k8s.io/user/quick-start.html).
+
+Release files are available https://github.com/weaveworks/cluster-bootstrap-controller/releases
+
+You can install these e.g.
+
+```shell
+$ kubectl apply -f https://github.com/weaveworks/cluster-bootstrap-controller/releases/download/v0.0.5/cluster-bootstrap-controller-v0.0.5.yaml
+```
+

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -33,6 +33,12 @@ spec:
         name: manager
         securityContext:
           allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          capabilities:
+            drop: [ "ALL" ]
+          seccompProfile:
+            type: RuntimeDefault
         livenessProbe:
           httpGet:
             path: /healthz


### PR DESCRIPTION
This drops the privileges when creating the deployment.

Some additional documentation on deploying.

When installing with a current install you get...

```$ k apply -f https://github.com/weaveworks/cluster-bootstrap-controller/releases/download/v0.0.5/cluster-bootstrap-controller-v0.0.5.yaml
...
service/cluster-bootstrap-controller-controller-manager-metrics-service created
Warning: would violate PodSecurity "restricted:latest": allowPrivilegeEscalation != false (container "kube-rbac-proxy" must set securityContext.allowPrivilegeEscalation=false), unrestricted capabilities (containers "kube-rbac-proxy", "manager" must set securityContext.capabilities.drop=["ALL"]), seccompProfile (pod or containers "kube-rbac-proxy", "manager" must set securityContext.seccompProfile.type to "RuntimeDefault" or "Localhost")
deployment.apps/cluster-bootstrap-controller-controller-manager created
```