### PR TITLE
Configure the github release action for private go modules

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -20,6 +20,11 @@ jobs:
       with:
         fetch-depth: 0
         ref: ${{ github.event.pull_request.head.sha }}
+    - name: Configure git for private modules
+      env:
+        GITHUB_BUILD_USERNAME: ${{ secrets.BUILD_BOT_USER }}
+        GITHUB_BUILD_TOKEN: ${{ secrets.BUILD_BOT_PERSONAL_ACCESS_TOKEN }}
+      run: git config --global url."https://${GITHUB_BUILD_USERNAME}:${GITHUB_BUILD_TOKEN}@github.com".insteadOf "https://github.com"
     - name: Build docker image
       env:
         GITHUB_BUILD_USERNAME: ${{ secrets.BUILD_BOT_USER }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,6 +19,11 @@ jobs:
       with:
         fetch-depth: 0
         ref: ${{ github.event.pull_request.head.sha }}
+    - name: Configure git for private modules
+      env:
+        GITHUB_BUILD_USERNAME: ${{ secrets.BUILD_BOT_USER }}
+        GITHUB_BUILD_TOKEN: ${{ secrets.BUILD_BOT_PERSONAL_ACCESS_TOKEN }}
+      run: git config --global url."https://${GITHUB_BUILD_USERNAME}:${GITHUB_BUILD_TOKEN}@github.com".insteadOf "https://github.com"
     - name: Build docker image
       env:
         GITHUB_BUILD_USERNAME: ${{ secrets.BUILD_BOT_USER }}


### PR DESCRIPTION
- cluster-controller (private repo) was introduced as a go dep in #11 and we need to do the classic git hacks to allow go mod to read the new private repo dependency