### PR TITLE
Allow multiple bootstraps with different configs.

### DIFF
--- a/api/v1alpha1/clusterbootstrapconfig_types.go
+++ b/api/v1alpha1/clusterbootstrapconfig_types.go
@@ -25,7 +25,10 @@ import (
 
 const defaultWaitDuration = time.Second * 60
 
-const BootstrappedAnnotation = "capi.weave.works/bootstrapped"
+const (
+	BootstrappedAnnotation     = "capi.weave.works/bootstrapped"
+	BootstrapConfigsAnnotation = "capi.weave.works/bootstrap-configs"
+)
 
 // JobTemplate describes a job to create
 type JobTemplate struct {


### PR DESCRIPTION
This allows for multiple bootstrap configs to trigger for the same cluster.

The namespace/name of each CBC that has acted is recorded as an annotation on the GitOpsCluster.

This could trigger rebootstraps of existing clusters, but we don't currently have a record of which CBC bootstrapped a cluster.