### PR TITLE
Don't wait for ControlPlane readiness for secrets.

### DIFF
--- a/controllers/cluster.go
+++ b/controllers/cluster.go
@@ -23,6 +23,8 @@ const (
 
 // IsControlPlaneReady takes a client connected to a cluster and reports whether or
 // not the control-plane for the cluster is "ready".
+//
+// WARNING: This does not work for "managed clusters" where the control-plane is not available.
 func IsControlPlaneReady(ctx context.Context, cl client.Client) (bool, error) {
 	logger := log.FromContext(ctx)
 	readiness := []bool{}
@@ -48,6 +50,7 @@ func IsControlPlaneReady(ctx context.Context, cl client.Client) (bool, error) {
 		}
 		return true
 	}
+
 	logger.Info("readiness", "len", len(readiness), "is-ready", isReady(readiness))
 
 	// If we have no statuses, then we really don't know if we're ready or not.

--- a/controllers/common.go
+++ b/controllers/common.go
@@ -4,4 +4,5 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
+// ConfigParser functions parse a byte slice and return a Kubernetes client.
 type ConfigParser func(b []byte) (client.Client, error)

--- a/controllers/secretsync_controller.go
+++ b/controllers/secretsync_controller.go
@@ -146,18 +146,6 @@ func (r *SecretSyncReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 			return ctrl.Result{}, fmt.Errorf("failed to create client for cluster %s: %w", clusterName, err)
 		}
 
-		ready, err := IsControlPlaneReady(ctx, clusterClient)
-		if err != nil {
-			logger.Error(err, "failed to check readiness of cluster", "cluster", cluster.Name)
-			continue
-		}
-
-		if !ready {
-			logger.Info("waiting for control plane to be ready", "cluster", cluster.Name)
-			requeue = true
-			continue
-		}
-
 		if err := r.syncSecret(ctx, secret, clusterClient, secretSync.Spec.TargetNamespace); err != nil {
 			logger.Error(err, "failed to sync secret", "cluster", cluster.Name, "secret", secret.Name)
 			continue


### PR DESCRIPTION
Remove the check for the IsControlPlaneReady in the secret syncing.

This isn't needed and the secret might be valuable for downloading things like a CNI Helm Chart.

We need IsControlPlaneReady more in the Job because it might be accessing network resources (think `flux bootstrap`).