### PR TITLE
Don't add empty elements to the list of configs.

### DIFF
--- a/controllers/clusterbootstrapconfig_controller_test.go
+++ b/controllers/clusterbootstrapconfig_controller_test.go
@@ -139,6 +139,15 @@ func TestReconcile_when_cluster_ready(t *testing.T) {
 	if l := len(jobs.Items); l != 1 {
 		t.Fatalf("found %d jobs, want %d", l, 1)
 	}
+
+	// reload the Cluster to check the state
+	if err := reconciler.Get(context.TODO(), client.ObjectKeyFromObject(cl), cl); err != nil {
+		t.Fatal(err)
+	}
+
+	if v := cl.ObjectMeta.Annotations[capiv1alpha1.BootstrapConfigsAnnotation]; v != "testing/test-config" {
+		t.Fatalf("got bootstrapped configs %q, want %q", v, "testing/test-config")
+	}
 }
 
 func TestReconcile_when_cluster_ready_bootstrapped_with_same_config(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/weaveworks/cluster-bootstrap-controller
 
-go 1.19
+go 1.20
 
 require (
 	github.com/fluxcd/pkg/runtime v0.35.0


### PR DESCRIPTION
Previusly, we added strings.Split() which when there is no "," was returning the original string which was "".

This mean that we got an empty element in the set, and so the generated annotation looked like ,test-ns/test-name with a leading comma for the empty element.

This strips out empty elements, this has no technical change, it's purely aesthetic.