### PR TITLE
Bump the GitHub actions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -60,7 +60,7 @@ jobs:
         run: echo "::set-output name=VERSION::$(make version)"
 
       - name: Log in to the Container registry
-        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+        uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -68,7 +68,7 @@ jobs:
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
+        uses: docker/metadata-action@v5
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
 
@@ -82,7 +82,7 @@ jobs:
         run: go mod vendor
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
+        uses: docker/build-push-action@v5
         with:
           context: .
           push: true


### PR DESCRIPTION
We're getting this message

The following actions uses node12 which is deprecated and will be forced to run on node16:

docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9, docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38, docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc.

For more info: https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/

This bumps the actions to the latest versions.